### PR TITLE
ci: initial commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,7 @@ jobs:
         steps:
           - name: Checkout
             uses: actions/checkout@v3
-          - name: Set up QEMU
-            uses: docker/setup-qemu-action@v2
+
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v2
   

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,51 @@
+name: Build Docker Images
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch: 
+
+jobs:
+      createMatrix:
+        runs-on: ubuntu-22.04
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+    
+          - name: Generate Matrix
+            id: matrix
+            run: |
+              # Get a list of all directories that have a Dockerfile
+              paths=$((ls -d */Dockerfile) | sed 's/\/Dockerfile//')
+              # Add all paths to a json array using jq
+              values=$(jq -n --arg array "${paths}" '$array | split("\n")')
+              echo matrix=${values} >> $GITHUB_OUTPUT
+            working-directory: servers
+    
+        outputs:
+          matrix: ${{ steps.matrix.outputs.matrix }}
+    
+      docker-build:
+        runs-on: ubuntu-22.04
+        needs: [createMatrix]
+        strategy:
+          matrix:
+            paths: servers/${{ fromJson(needs.createMatrix.outputs.matrix) }}
+    
+        env:
+          MATRIX_PATH: ${{ matrix.paths }}
+    
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v2
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v2
+  
+          - name: Build and push
+            uses: docker/build-push-action@v4
+            with:
+              context: "{{defaultContext}}:servers/${{ matrix.MATRIX_PATH }}"
+              push: false
+              tags: "quick-hello:${{ matrix.MATRIX_PATH }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   workflow_dispatch: 
+  pull_request:
 
 jobs:
       createMatrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           - name: Build and push
             uses: docker/build-push-action@v4
             with:
-              context: "{{defaultContext}}:servers:${{ env.MATRIX_PATH }}"
+              context: "{{defaultContext}}:servers/${{ env.MATRIX_PATH }}"
               push: false
               tags: "quick-hello:${{ env.MATRIX_PATH }}"
               

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           - name: Build and push
             uses: docker/build-push-action@v4
             with:
-              context: "{{defaultContext}}:servers:${{ matrix.MATRIX_PATH }}"
+              context: "{{defaultContext}}:servers:${{ env.MATRIX_PATH }}"
               push: false
-              tags: "quick-hello:${{ matrix.MATRIX_PATH }}"
+              tags: "quick-hello:${{ env.MATRIX_PATH }}"
               

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           - name: Build and push
             uses: docker/build-push-action@v4
             with:
-              context: "servers/${{ matrix.MATRIX_PATH }}"
+              context: "{{defaultContext}}:servers:${{ matrix.MATRIX_PATH }}"
               push: false
               tags: "quick-hello:${{ matrix.MATRIX_PATH }}"
               

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         needs: [createMatrix]
         strategy:
           matrix:
-            paths: servers/${{ fromJson(needs.createMatrix.outputs.matrix) }}
+            paths: ${{ fromJson(needs.createMatrix.outputs.matrix) }}
     
         env:
           MATRIX_PATH: ${{ matrix.paths }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,7 @@ jobs:
           - name: Build and push
             uses: docker/build-push-action@v4
             with:
-              context: "{{defaultContext}}:servers/${{ matrix.MATRIX_PATH }}"
+              context: "servers/${{ matrix.MATRIX_PATH }}"
               push: false
               tags: "quick-hello:${{ matrix.MATRIX_PATH }}"
+              

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,9 +44,17 @@ jobs:
             uses: docker/setup-buildx-action@v2
   
           - name: Build and push
+            if: github.event_name == 'push' && github.ref == 'refs/heads/main'
             uses: docker/build-push-action@v4
             with:
               context: "{{defaultContext}}:servers/${{ env.MATRIX_PATH }}"
               push: false
               tags: "quick-hello:${{ env.MATRIX_PATH }}"
-              
+
+          - name: Build only
+            if: github.event_name != 'push'
+            uses: docker/build-push-action@v4
+            with:
+              context: "{{defaultContext}}:servers/${{ env.MATRIX_PATH }}"
+              push: false
+              tags: "quick-hello:${{ env.MATRIX_PATH }}"


### PR DESCRIPTION
Create a basic Docker CI/CD workflow.  In the future, this will push images.  Currently:  
- On pull request, dispatch, and push to mian, it will build docker images in any directory in `servers/` with a Dockerfile.
- Each image will be tagged according to folder name, e.g. `quick-hello:node-vanilla`